### PR TITLE
upgrade Go from 1.21 to 1.23

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,27 +1,15 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
 	"name": "Go",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1.21",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.23",
 	"runArgs": [ "--userns=keep-id" ],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "go version",
-
-	// Configure tool-specific properties.
 	"customizations": {
-		// Configure properties specific to VS Code.
 		"vscode": {
-			// Set *default* container specific settings.json values on container create.
 			"settings": {
 				"go.toolsManagement.checkForUpdates": "local",
 				"go.useLanguageServer": true,
 				"go.gopath": "/go",
 				"go.goroot": "/usr/local/go"
 			},
-
-			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"DavidAnson.vscode-markdownlint",
 				"EditorConfig.EditorConfig",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/JakeTRogers/timeBuddy
 
-go 1.21
+go 1.23
 
 require (
 	github.com/jedib0t/go-pretty/v6 v6.6.6


### PR DESCRIPTION
This pull request updates the development environment and dependencies for the `timeBuddy` project. The most important changes include updating the Go version in both the `devcontainer.json` and `go.mod` files.

Development environment updates:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L1-L24): Updated the Go image version from `1.21` to `1.23`.

Dependency updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.21` to `1.23`.