### PR TITLE
eliminate global state in root command and improve test isolation

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -7,7 +7,7 @@ commitizen:
   tag_format: v$version
   update_changelog_on_bump: true
   use_shortcuts: true
-  version: 2.0.1
+  version: 2.0.2
   version_files:
   - cmd/root.go
   version_scheme: semver

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,22 @@ repos:
     rev: 9f61b0f53f80672872fced07b6874397c3ed197b  # frozen: v2.7.2
     hooks:
       - id: golangci-lint-full
+  - repo: local
+    hooks:
+      - id: go-test
+        name: go test
+        entry: go test ./... -race -coverprofile=coverage.out
+        language: system
+        pass_filenames: false
+        types: [go]
+        stages: [pre-commit]
+      - id: go-test-coverage
+        name: go test coverage check (cmd package)
+        entry: bash -c 'go test -coverprofile=coverage.out ./... > /dev/null 2>&1 && COVERAGE=$(go tool cover -func=coverage.out | grep "^total:" | awk "{print \$3}" | sed "s/%//"); if (( $(echo "$COVERAGE < 85" | bc -l) )); then echo "Coverage below 85% ${COVERAGE}%"; exit 1; else echo "Coverage OK ${COVERAGE}%"; fi'
+        language: system
+        pass_filenames: false
+        types: [go]
+        stages: [pre-commit]
   - repo: https://github.com/commitizen-tools/commitizen
     rev: 9f3ec868c0429155a46b4819b625d47a8522a3d5  # frozen: v4.10.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0.2 (2025-12-29)
+
+### Refactor
+
+- eliminate global state in root & sub-commands to improve testability; enhance logging
+
 ## v2.0.1 (2025-12-28)
 
 ### Refactor

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -34,12 +34,14 @@ func assertLocationInArea(t *testing.T, areas map[string][]string, area, locatio
 }
 
 func Test_timezonesAll_notEmpty(t *testing.T) {
+	t.Parallel()
 	if len(timezonesAll) == 0 {
 		t.Error("timezonesAll should not be empty")
 	}
 }
 
 func Test_timezonesAll_containsKnown(t *testing.T) {
+	t.Parallel()
 	knownTimezones := []string{
 		"America/New_York",
 		"Europe/London",
@@ -50,18 +52,22 @@ func Test_timezonesAll_containsKnown(t *testing.T) {
 
 	for _, tz := range knownTimezones {
 		t.Run(tz, func(t *testing.T) {
+			t.Parallel()
 			assertTimezoneExists(t, tz)
 		})
 	}
 }
 
-func Test_listCmd_exists(t *testing.T) {
+func Test_NewListCmd_exists(t *testing.T) {
+	t.Parallel()
+	listCmd := NewListCmd()
 	if listCmd == nil {
-		t.Error("listCmd should not be nil")
+		t.Error("NewListCmd() should not return nil")
 	}
 }
 
 func Test_listAreas(t *testing.T) {
+	t.Parallel()
 	result := listAreas()
 
 	if len(result) == 0 {
@@ -69,6 +75,7 @@ func Test_listAreas(t *testing.T) {
 	}
 
 	t.Run("known areas exist", func(t *testing.T) {
+		t.Parallel()
 		knownAreas := []string{"America", "Europe", "Asia", "Australia", "Africa"}
 		for _, area := range knownAreas {
 			if _, exists := result[area]; !exists {
@@ -78,6 +85,7 @@ func Test_listAreas(t *testing.T) {
 	})
 
 	t.Run("timezone parsing", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			area     string
 			location string
@@ -90,13 +98,15 @@ func Test_listAreas(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.area+"/"+tt.location, func(t *testing.T) {
+				t.Parallel()
 				assertLocationInArea(t, result, tt.area, tt.location)
 			})
 		}
 	})
 }
 
-func Test_listCmd_flags(t *testing.T) {
+func Test_NewListCmd_flags(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		flagName string
@@ -108,6 +118,8 @@ func Test_listCmd_flags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			listCmd := NewListCmd()
 			flag := listCmd.Flags().Lookup(tt.flagName)
 			if flag == nil {
 				t.Errorf("listCmd should have a '%s' flag", tt.flagName)
@@ -116,8 +128,9 @@ func Test_listCmd_flags(t *testing.T) {
 	}
 }
 
-// Test_validateListArgs tests the validateListArgs function
-func Test_validateListArgs(t *testing.T) {
+// Test_validateListArgs tests the validateListArgs function via the command
+func Test_validateListArgs_via_cmd(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		setupCmd      func(*cobra.Command)
@@ -148,21 +161,16 @@ func Test_validateListArgs(t *testing.T) {
 		},
 	}
 
-	// Save original area value
-	originalArea := area
-	t.Cleanup(func() {
-		area = originalArea
-	})
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create test command with required flags
-			cmd := &cobra.Command{}
-			cmd.Flags().StringVarP(&area, "locations", "l", "", "")
+			t.Parallel()
+			// Create a fresh list command for each test
+			listCmd := NewListCmd()
 
-			tt.setupCmd(cmd)
+			tt.setupCmd(listCmd)
 
-			err := validateListArgs(cmd, nil)
+			// Execute Args validator
+			err := listCmd.Args(listCmd, nil)
 
 			if tt.expectError {
 				if err == nil {
@@ -177,8 +185,9 @@ func Test_validateListArgs(t *testing.T) {
 	}
 }
 
-// Test_runList tests the runList function
-func Test_runList(t *testing.T) {
+// Test_runList tests the runList function via the command
+func Test_runList_via_cmd(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		setupCmd func(*cobra.Command)
@@ -203,23 +212,16 @@ func Test_runList(t *testing.T) {
 		},
 	}
 
-	// Save original area value
-	originalArea := area
-	t.Cleanup(func() {
-		area = originalArea
-	})
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create test command with required flags
-			cmd := &cobra.Command{}
-			cmd.Flags().Bool("areas", false, "")
-			cmd.Flags().StringVarP(&area, "locations", "l", "", "")
-			cmd.Flags().Bool("timezones", false, "")
+			t.Parallel()
+			// Create a fresh list command for each test
+			listCmd := NewListCmd()
 
-			tt.setupCmd(cmd)
+			tt.setupCmd(listCmd)
 
-			err := runList(cmd, nil)
+			// Execute RunE
+			err := listCmd.RunE(listCmd, nil)
 			if err != nil {
 				t.Errorf("runList failed: %v", err)
 			}
@@ -229,6 +231,7 @@ func Test_runList(t *testing.T) {
 
 // Test_printAreas tests the printAreas function
 func Test_printAreas(t *testing.T) {
+	t.Parallel()
 	// Test that it doesn't panic and returns nil
 	err := printAreas()
 	if err != nil {
@@ -238,6 +241,7 @@ func Test_printAreas(t *testing.T) {
 
 // Test_printLocations tests the printLocations function
 func Test_printLocations(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		areaName    string
@@ -257,11 +261,8 @@ func Test_printLocations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create test command with required flags
-			cmd := &cobra.Command{}
-			cmd.Flags().String("locations", tt.areaName, "")
-
-			err := printLocations(cmd)
+			t.Parallel()
+			err := printLocations(tt.areaName)
 
 			if tt.expectError {
 				if err == nil {
@@ -276,6 +277,7 @@ func Test_printLocations(t *testing.T) {
 
 // Test_printAllTimezones tests the printAllTimezones function
 func Test_printAllTimezones(t *testing.T) {
+	t.Parallel()
 	err := printAllTimezones()
 	if err != nil {
 		t.Errorf("printAllTimezones failed: %v", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ func NewRootCmd() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:     "timeBuddy",
-		Version: "v2.0.1",
+		Version: "v2.0.2",
 		Short:   "CLI version of World Time Buddy",
 		Long: `timeBuddy is a Command Line Interface (CLI) tool designed to display the current time across multiple time zones. This
 tool is particularly useful for scheduling meetings with participants in various time zones. By default, timeBuddy

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/JakeTRogers/timeBuddy/logger"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -27,20 +28,6 @@ import (
 // replaceHyphenWithCamelCase controls viper config name conversion.
 // Set to true if config file uses camelCase instead of hyphenated keys.
 const replaceHyphenWithCamelCase = false
-
-// Package-level state for CLI flags and configuration.
-// These are bound to CLI flags and persisted via Viper.
-var (
-	colorEnabled      bool
-	highlight         string
-	liveMode          bool
-	liveInterval      int
-	twelveHourEnabled bool
-	date              string
-	timezones         []string
-	v                 = viper.New()
-	log               = logger.GetLogger()
-)
 
 // timezoneDetail holds timezone information for display.
 type timezoneDetail struct {
@@ -55,12 +42,171 @@ type timezoneDetail struct {
 // timezoneDetails is a slice of timezoneDetail for table rendering.
 type timezoneDetails []timezoneDetail
 
+// NewRootCmd creates and returns a new root command with all flags and subcommands configured.
+// Each call returns a fresh instance for test isolation.
+func NewRootCmd() *cobra.Command {
+	// Flag variables local to this command instance
+	var (
+		colorEnabled      bool
+		highlight         string
+		liveMode          bool
+		liveInterval      int
+		twelveHourEnabled bool
+		date              string
+		timezones         []string
+		v                 = viper.New()
+		log               = logger.GetLogger()
+	)
+
+	rootCmd := &cobra.Command{
+		Use:     "timeBuddy",
+		Version: "v2.0.1",
+		Short:   "CLI version of World Time Buddy",
+		Long: `timeBuddy is a Command Line Interface (CLI) tool designed to display the current time across multiple time zones. This
+tool is particularly useful for scheduling meetings with participants in various time zones. By default, timeBuddy
+includes your local time zone in its output. You can exclude your local time zone using the --exclude-local flag.
+
+timeBuddy saves your most recent time zone selections in a configuration file. This feature ensures that you need to
+specify your preferred time zones only once. The order in which you specify the time zones is retained and reflected in
+the table output. You can find the configuration file at the following locations:
+
+  - Linux/Mac: $HOME/.config/.timeBuddy.yaml
+  - Windows: %APPDATA%\.timeBuddy.yaml
+
+Examples:
+
+  # Display your local time zone or those saved in the config file from your last session:
+  $ timeBuddy
+
+  # Display the current time for a selection of time zones:
+  $ timeBuddy --timezone America/New_York --timezone Europe/Vilnius --timezone Australia/Sydney
+
+  # Display Time for a specific date and highlight 3pm AEDT(useful for Daylight Saving Time changes):
+  $ timeBuddy --date 2023-11-05 --highlight 15+11
+
+  # Exclude your local time zone from the output:
+   $ timeBuddy --exclude-local --timezone --timezone Europe/London --timezone Asia/Tokyo
+
+  # Enable colorized table output:
+   $ timeBuddy --color
+
+  # Enable live mode to continuously update the display:
+   $ timeBuddy --live
+
+  # Enable live mode with a custom refresh interval (every 5 seconds):
+   $ timeBuddy --live --interval 5
+
+Learn More:
+  To submit feature requests, bugs, or to check for new versions, visit https://github.com/JakeTRogers/timeBuddy`,
+	}
+
+	// validateArgs validates command arguments before execution.
+	validateArgs := func(cmd *cobra.Command, args []string) error {
+		log.Trace().Msg("validating command arguments")
+
+		if err := validateLiveDateExclusion(cmd); err != nil {
+			return err
+		}
+
+		if cmd.Flags().Changed("date") {
+			if _, err := time.Parse(time.DateOnly, date); err != nil {
+				return fmt.Errorf("invalid date %q: %w", date, err)
+			}
+		}
+
+		if !cmd.Flags().Changed("exclude-local") {
+			if err := addLocalTimezone(&timezones, log); err != nil {
+				return err
+			}
+		}
+
+		timezones = deduplicateSlice(timezones)
+		log.Debug().Strs("timezones", timezones).Msg("timezones after validation")
+		return nil
+	}
+
+	// persistentPreRunE initializes configuration before command execution.
+	persistentPreRunE := func(cmd *cobra.Command, args []string) error {
+		return initializeConfig(cmd, v, log)
+	}
+
+	// runRoot executes the main timeBuddy command logic.
+	runRoot := func(cmd *cobra.Command, args []string) error {
+		if wizardMode, _ := cmd.Flags().GetBool("wizard"); wizardMode {
+			return handleWizardMode(v, log, &timezones)
+		}
+
+		for k, val := range v.AllSettings() {
+			log.Debug().Str(k, fmt.Sprintf("%v", val)).Msg("viper setting")
+		}
+
+		saveUserPreferences(v, log, colorEnabled, twelveHourEnabled, timezones)
+
+		if liveMode {
+			return runLiveMode(cmd, log, &timezones, &date, colorEnabled, twelveHourEnabled, &highlight)
+		}
+
+		zones, err := processTimezones(timezones, date, log)
+		if err != nil {
+			return err
+		}
+
+		highlightHour, err := processHighlightFlag(cmd, zones, highlight, log)
+		if err != nil {
+			return fmt.Errorf("invalid highlight specification: %w", err)
+		}
+
+		printTimeTable(zones, colorEnabled, highlightHour, twelveHourEnabled, date, log)
+		return nil
+	}
+
+	rootCmd.Args = validateArgs
+	rootCmd.PersistentPreRunE = persistentPreRunE
+	rootCmd.RunE = runRoot
+
+	rootCmd.SetVersionTemplate(`{{printf "timeBuddy %s\n" .Version}}`)
+
+	// Display flags
+	rootCmd.Flags().BoolVarP(&colorEnabled, "color", "c", false, "enable colorized table output. If previously enabled, use --color=false to disable it,")
+	rootCmd.Flags().StringVarP(&date, "date", "d", time.Now().Format(time.DateOnly), "``date to use for time conversion. Expects YYYY-MM-DD format. Defaults to current date/time.")
+	rootCmd.Flags().StringVarP(&highlight, "highlight", "H", "", "highlight hour column (0-23), optionally with UTC offset (e.g., '15+11' or '9-4')")
+	rootCmd.Flags().BoolVarP(&twelveHourEnabled, "twelve-hour", "t", false, "use 12-hour time format instead of 24-hour. If previously enabled, use --twelve-hour=false to disable it.")
+
+	// Live mode flags
+	rootCmd.Flags().BoolVarP(&liveMode, "live", "l", false, "enable live mode to continuously refresh the time display (press Ctrl+C to exit)")
+	rootCmd.Flags().IntVarP(&liveInterval, "interval", "i", 1, "refresh interval in seconds for live mode")
+
+	// Timezone selection flags
+	rootCmd.Flags().BoolP("exclude-local", "x", false, "disable default behavior of including local timezone in output")
+	rootCmd.Flags().BoolP("wizard", "w", false, "launch interactive timezone selector wizard")
+	rootCmd.Flags().StringArrayVarP(&timezones, "timezone", "z", []string{}, "``timezone to use for time conversion. Accepts timezone name, like America/New_York. Can be used multiple times.")
+
+	// Logging flags
+	rootCmd.PersistentFlags().CountP("verbose", "v", "``increase logging verbosity, 1=warn, 2=info, 3=debug, 4=trace")
+
+	// Mutual exclusion
+	rootCmd.MarkFlagsMutuallyExclusive("live", "date")
+
+	// Tab completion for timezone flag
+	if err := rootCmd.RegisterFlagCompletionFunc("timezone", completeTimezone); err != nil {
+		log.Error().Err(err).Msg("failed to register timezone completion")
+	}
+
+	// Add subcommands
+	rootCmd.AddCommand(NewListCmd())
+	rootCmd.AddCommand(NewWizardCmd(v))
+
+	return rootCmd
+}
+
 // initializeConfig initializes Viper configuration for the root command.
 // It sets up the config file path, reads existing config, creates a new one
 // if none exists, and binds command flags to configuration values.
-func initializeConfig(cmd *cobra.Command) error {
+func initializeConfig(cmd *cobra.Command, v *viper.Viper, log *zerolog.Logger) error {
 	verboseCount, _ := cmd.Flags().GetCount("verbose")
 	logger.SetLogLevel(verboseCount)
+
+	log.Info().Int("verbosity", verboseCount).Msg("initializing configuration")
 
 	configName := ".timeBuddy"
 	configType := "yaml"
@@ -73,28 +219,31 @@ func initializeConfig(cmd *cobra.Command) error {
 	}
 
 	configFile := filepath.Join(configPath, configName+"."+configType)
-	log.Debug().Str("configPath", configPath).Str("configFile", configFile).Send()
+	log.Debug().Str("configPath", configPath).Str("configFile", configFile).Msg("config file location")
 
 	v.AddConfigPath(configPath)
 	v.SetConfigFile(configFile)
 
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			log.Info().Str("configFile", configFile).Msg("creating new config file")
 			if writeErr := v.SafeWriteConfigAs(configFile); writeErr != nil {
 				log.Error().Err(writeErr).Msg("failed to create config file")
 			} else {
-				log.Info().Str("configFile", configFile).Msg("new config file created")
+				log.Info().Str("configFile", configFile).Msg("config file created successfully")
 			}
 		} else {
-			log.Error().Str("viper", err.Error()).Send()
+			log.Error().Err(err).Msg("failed to read config file")
 		}
+	} else {
+		log.Debug().Str("configFile", configFile).Msg("config file loaded")
 	}
 
 	v.SetEnvPrefix("TIMEBUDDY")
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	v.AutomaticEnv()
 
-	bindFlags(cmd, v)
+	bindFlags(cmd, v, log)
 
 	return nil
 }
@@ -109,38 +258,42 @@ func getConfigPath() string {
 
 // bindFlags binds command flags to Viper configuration values.
 // It applies config file values to flags that haven't been explicitly set.
-func bindFlags(cmd *cobra.Command, v *viper.Viper) {
+func bindFlags(cmd *cobra.Command, v *viper.Viper, log *zerolog.Logger) {
+	log.Debug().Msg("binding flags to viper config")
+
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		configName := f.Name
 		if replaceHyphenWithCamelCase {
 			configName = strings.ReplaceAll(f.Name, "-", "")
 		}
 
-		log.Debug().Str("flag", f.Name).Str("configName", configName).Msg("binding flag to viper config")
+		log.Trace().Str("flag", f.Name).Str("configName", configName).Bool("changed", f.Changed).Msg("processing flag")
 
 		if f.Changed || !v.IsSet(configName) {
 			return
 		}
 
 		val := v.Get(configName)
-		if arr, ok := val.([]interface{}); ok {
+		if arr, ok := val.([]any); ok {
 			for _, item := range arr {
 				if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", item)); err != nil {
-					log.Error().Str("viper", err.Error()).Send()
+					log.Error().Err(err).Str("flag", f.Name).Msg("failed to set array flag from config")
 				}
 			}
 			return
 		}
 
 		if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-			log.Error().Str("viper", err.Error()).Send()
+			log.Error().Err(err).Str("flag", f.Name).Msg("failed to set flag from config")
 		}
 	})
 }
 
 // getZoneInfo returns timezone details for the given timezone and date.
 // It validates the timezone and date, then computes offset and hours.
-func getZoneInfo(timezone string, date string) (timezoneDetail, error) {
+func getZoneInfo(timezone string, date string, log *zerolog.Logger) (timezoneDetail, error) {
+	log.Trace().Str("timezone", timezone).Str("date", date).Msg("getting zone info")
+
 	loc, err := time.LoadLocation(timezone)
 	if err != nil {
 		return timezoneDetail{}, fmt.Errorf("invalid timezone %q: %w", timezone, err)
@@ -171,9 +324,9 @@ func getZoneInfo(timezone string, date string) (timezoneDetail, error) {
 		Str("abbreviation", zone.abbreviation).
 		Str("currentTime", zone.currentTime.String()).
 		Int("offsetMinutes", zone.offsetMinutes).
-		Send()
+		Msg("zone info computed")
 
-	hours, err := getHours(date, loc)
+	hours, err := getHours(date, loc, log)
 	if err != nil {
 		return timezoneDetail{}, fmt.Errorf("failed to get hours for timezone %q: %w", timezone, err)
 	}
@@ -184,7 +337,9 @@ func getZoneInfo(timezone string, date string) (timezoneDetail, error) {
 
 // getHours returns 24 hours for the given date in the specified timezone.
 // Each hour represents the time at that UTC hour converted to the location.
-func getHours(date string, location *time.Location) ([]time.Time, error) {
+func getHours(date string, location *time.Location, log *zerolog.Logger) ([]time.Time, error) {
+	log.Trace().Str("date", date).Str("location", location.String()).Msg("computing hours for day")
+
 	d, err := time.ParseInLocation(time.DateOnly, date, time.UTC)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse date %q: %w", date, err)
@@ -201,8 +356,8 @@ func getHours(date string, location *time.Location) ([]time.Time, error) {
 
 // formatHours formats the hours for display in the time table.
 // When twelveHourEnabled is true, uses 12-hour format with am/pm.
-func formatHours(z timezoneDetail, twelveHourEnabled bool) []interface{} {
-	hours := make([]interface{}, len(z.hours))
+func formatHours(z timezoneDetail, twelveHourEnabled bool) []any {
+	hours := make([]any, len(z.hours))
 	for i, t := range z.hours {
 		hour24 := t.Hour()
 		if hour24 == 0 {
@@ -262,6 +417,10 @@ func formatRowLabel(z timezoneDetail, date, offset string) string {
 // parseOffset parses a highlight string like "hour+offset" or "hour-offset".
 // Returns the hour (0-23), offset in minutes, and any parsing error.
 func parseOffset(input string) (hour int, offsetMinutes int, err error) {
+	if input == "" {
+		return 0, 0, fmt.Errorf("empty highlight value")
+	}
+
 	sep := strings.IndexAny(input[1:], "+-")
 	if sep != -1 {
 		sep++ // account for slicing from index 1
@@ -423,7 +582,9 @@ func hasTimezoneWithOffset(zones timezoneDetails, offsetMinutes int) bool {
 
 // printTimeTable renders the timezone table to stdout.
 // Uses go-pretty for table formatting with optional color styling.
-func printTimeTable(zones timezoneDetails, colorEnabled bool, highlightHour int) {
+func printTimeTable(zones timezoneDetails, colorEnabled bool, highlightHour int, twelveHourEnabled bool, date string, log *zerolog.Logger) {
+	log.Debug().Int("zoneCount", len(zones)).Bool("color", colorEnabled).Int("highlightHour", highlightHour).Msg("rendering time table")
+
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 
@@ -454,11 +615,12 @@ func printTimeTable(zones timezoneDetails, colorEnabled bool, highlightHour int)
 		hours := formatHours(z, twelveHourEnabled)
 		offset := formatOffset(z)
 		rowLabel := formatRowLabel(z, date, offset)
-		row := append([]interface{}{rowLabel}, hours...)
+		row := append([]any{rowLabel}, hours...)
 		t.AppendRow(row)
 	}
 
 	t.Render()
+	log.Info().Int("zoneCount", len(zones)).Msg("time table rendered")
 }
 
 // configureColoredTable applies colored style to the table.
@@ -493,141 +655,45 @@ func deduplicateSlice(s []string) []string {
 	return result
 }
 
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:     "timeBuddy",
-	Version: "v2.0.1",
-	Short:   "CLI version of World Time Buddy",
-	Long: `timeBuddy is a Command Line Interface (CLI) tool designed to display the current time across multiple time zones. This
-tool is particularly useful for scheduling meetings with participants in various time zones. By default, timeBuddy
-includes your local time zone in its output. You can exclude your local time zone using the --exclude-local flag.
-
-timeBuddy saves your most recent time zone selections in a configuration file. This feature ensures that you need to
-specify your preferred time zones only once. The order in which you specify the time zones is retained and reflected in
-the table output. You can find the configuration file at the following locations:
-
-  - Linux/Mac: $HOME/.config/.timeBuddy.yaml
-  - Windows: %APPDATA%\.timeBuddy.yaml
-
-Examples:
-
-  # Display your local time zone or those saved in the config file from your last session:
-  $ timeBuddy
-
-  # Display the current time for a selection of time zones:
-  $ timeBuddy --timezone America/New_York --timezone Europe/Vilnius --timezone Australia/Sydney
-
-  # Display Time for a specific date and highlight 3pm AEDT(useful for Daylight Saving Time changes):
-  $ timeBuddy --date 2023-11-05 --highlight 15+11
-
-  # Exclude your local time zone from the output:
-   $ timeBuddy --exclude-local --timezone --timezone Europe/London --timezone Asia/Tokyo
-
-  # Enable colorized table output:
-   $ timeBuddy --color
-
-  # Enable live mode to continuously update the display:
-   $ timeBuddy --live
-
-  # Enable live mode with a custom refresh interval (every 5 seconds):
-   $ timeBuddy --live --interval 5
-
-Learn More:
-  To submit feature requests, bugs, or to check for new versions, visit https://github.com/JakeTRogers/timeBuddy`,
-	Args:              validateArgs,
-	PersistentPreRunE: persistentPreRunE,
-	RunE:              runRoot,
-}
-
-// validateArgs validates command arguments before execution.
-func validateArgs(cmd *cobra.Command, args []string) error {
-	if err := validateLiveDateExclusion(cmd); err != nil {
-		return err
-	}
-
-	if cmd.Flags().Changed("date") {
-		if _, err := time.Parse(time.DateOnly, date); err != nil {
-			return fmt.Errorf("invalid date %q: %w", date, err)
-		}
-	}
-
-	if !cmd.Flags().Changed("exclude-local") {
-		if err := addLocalTimezone(); err != nil {
-			return err
-		}
-	}
-
-	timezones = deduplicateSlice(timezones)
-	return nil
-}
-
 // addLocalTimezone adds the local timezone to the timezones list if not present.
-func addLocalTimezone() error {
+func addLocalTimezone(timezones *[]string, log *zerolog.Logger) error {
 	ltz, err := time.LoadLocation("Local")
 	if err != nil {
 		return fmt.Errorf("failed to load local timezone: %w", err)
 	}
 
-	for _, tz := range timezones {
+	for _, tz := range *timezones {
 		if tz == ltz.String() {
+			log.Debug().Str("localTimezone", ltz.String()).Msg("local timezone already in list")
 			return nil
 		}
 	}
 
-	timezones = append([]string{ltz.String()}, timezones...)
-	return nil
-}
-
-// persistentPreRunE initializes configuration before command execution.
-func persistentPreRunE(cmd *cobra.Command, args []string) error {
-	return initializeConfig(cmd)
-}
-
-// runRoot executes the main timeBuddy command logic.
-func runRoot(cmd *cobra.Command, args []string) error {
-	if wizardMode, _ := cmd.Flags().GetBool("wizard"); wizardMode {
-		return handleWizardMode()
-	}
-
-	for k, val := range v.AllSettings() {
-		log.Debug().Str(k, fmt.Sprintf("%v", val)).Msg("viper")
-	}
-
-	saveUserPreferences()
-
-	if liveMode {
-		return runLiveMode(cmd)
-	}
-
-	zones, err := processTimezones()
-	if err != nil {
-		return err
-	}
-
-	highlightHour, err := processHighlightFlag(cmd, zones)
-	if err != nil {
-		return fmt.Errorf("invalid highlight specification: %w", err)
-	}
-
-	printTimeTable(zones, colorEnabled, highlightHour)
+	log.Debug().Str("localTimezone", ltz.String()).Msg("adding local timezone to list")
+	*timezones = append([]string{ltz.String()}, *timezones...)
 	return nil
 }
 
 // handleWizardMode runs the interactive timezone selector.
-func handleWizardMode() error {
-	selected, err := runWizard()
+func handleWizardMode(v *viper.Viper, log *zerolog.Logger, timezones *[]string) error {
+	log.Info().Msg("launching interactive timezone wizard")
+
+	selected, err := runWizard(v, log)
 	if err != nil {
 		return fmt.Errorf("wizard failed: %w", err)
 	}
 
 	if selected == nil {
+		log.Info().Msg("wizard cancelled, no changes saved")
 		return nil
 	}
 
-	timezones = selected
+	*timezones = selected
 	v.Set("timezone", selected)
 	if err := v.WriteConfig(); err != nil {
 		log.Error().Err(err).Msg("failed to save config")
+	} else {
+		log.Info().Int("count", len(selected)).Msg("timezone selections saved")
 	}
 	return nil
 }
@@ -638,14 +704,17 @@ func clearScreen() {
 }
 
 // runLiveMode continuously refreshes the time table at the configured interval.
-func runLiveMode(cmd *cobra.Command) error {
+func runLiveMode(cmd *cobra.Command, log *zerolog.Logger, timezones *[]string, date *string, colorEnabled, twelveHourEnabled bool, highlight *string) error {
+	liveInterval, _ := cmd.Flags().GetInt("interval")
+	log.Info().Int("interval", liveInterval).Msg("starting live mode")
+
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
 	ticker := time.NewTicker(time.Duration(liveInterval) * time.Second)
 	defer ticker.Stop()
 
-	if err := renderTimeTable(cmd); err != nil {
+	if err := renderTimeTable(cmd, log, *timezones, *date, colorEnabled, twelveHourEnabled, *highlight); err != nil {
 		return err
 	}
 
@@ -654,11 +723,12 @@ func runLiveMode(cmd *cobra.Command) error {
 	for {
 		select {
 		case <-sigChan:
+			log.Info().Msg("exiting live mode")
 			fmt.Println("\nExiting live mode...")
 			return nil
 		case <-ticker.C:
 			clearScreen()
-			if err := renderTimeTable(cmd); err != nil {
+			if err := renderTimeTable(cmd, log, *timezones, *date, colorEnabled, twelveHourEnabled, *highlight); err != nil {
 				log.Error().Err(err).Msg("failed to render time table")
 			}
 			fmt.Println("\nLive mode active. Press Ctrl+C to exit.")
@@ -667,53 +737,23 @@ func runLiveMode(cmd *cobra.Command) error {
 }
 
 // renderTimeTable processes timezones and renders the table.
-func renderTimeTable(cmd *cobra.Command) error {
-	zones, err := processTimezones()
+func renderTimeTable(cmd *cobra.Command, log *zerolog.Logger, timezones []string, date string, colorEnabled, twelveHourEnabled bool, highlight string) error {
+	zones, err := processTimezones(timezones, date, log)
 	if err != nil {
 		return err
 	}
-	highlightHour, err := processHighlightFlag(cmd, zones)
+	highlightHour, err := processHighlightFlag(cmd, zones, highlight, log)
 	if err != nil {
 		return fmt.Errorf("invalid highlight specification: %w", err)
 	}
-	printTimeTable(zones, colorEnabled, highlightHour)
+	printTimeTable(zones, colorEnabled, highlightHour, twelveHourEnabled, date, log)
 	return nil
 }
 
 // Execute runs the root command. Called from main.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	if err := NewRootCmd().Execute(); err != nil {
 		os.Exit(1)
-	}
-}
-
-func init() {
-	rootCmd.SetVersionTemplate(`{{printf "timeBuddy %s\n" .Version}}`)
-
-	// Display flags
-	rootCmd.Flags().BoolVarP(&colorEnabled, "color", "c", false, "enable colorized table output. If previously enabled, use --color=false to disable it,")
-	rootCmd.Flags().StringVarP(&date, "date", "d", time.Now().Format(time.DateOnly), "``date to use for time conversion. Expects YYYY-MM-DD format. Defaults to current date/time.")
-	rootCmd.Flags().StringVarP(&highlight, "highlight", "H", "", "highlight hour column (0-23), optionally with UTC offset (e.g., '15+11' or '9-4')")
-	rootCmd.Flags().BoolVarP(&twelveHourEnabled, "twelve-hour", "t", false, "use 12-hour time format instead of 24-hour. If previously enabled, use --twelve-hour=false to disable it.")
-
-	// Live mode flags
-	rootCmd.Flags().BoolVarP(&liveMode, "live", "l", false, "enable live mode to continuously refresh the time display (press Ctrl+C to exit)")
-	rootCmd.Flags().IntVarP(&liveInterval, "interval", "i", 1, "refresh interval in seconds for live mode")
-
-	// Timezone selection flags
-	rootCmd.Flags().BoolP("exclude-local", "x", false, "disable default behavior of including local timezone in output")
-	rootCmd.Flags().BoolP("wizard", "w", false, "launch interactive timezone selector wizard")
-	rootCmd.Flags().StringArrayVarP(&timezones, "timezone", "z", []string{}, "``timezone to use for time conversion. Accepts timezone name, like America/New_York. Can be used multiple times.")
-
-	// Logging flags
-	rootCmd.PersistentFlags().CountP("verbose", "v", "``increase logging verbosity, 1=warn, 2=info, 3=debug, 4=trace")
-
-	// Mutual exclusion
-	rootCmd.MarkFlagsMutuallyExclusive("live", "date")
-
-	// Tab completion for timezone flag
-	if err := rootCmd.RegisterFlagCompletionFunc("timezone", completeTimezone); err != nil {
-		log.Error().Err(err).Send()
 	}
 }
 
@@ -723,39 +763,50 @@ func completeTimezone(cmd *cobra.Command, args []string, toComplete string) ([]s
 }
 
 // saveUserPreferences persists current preferences to the config file.
-func saveUserPreferences() {
+func saveUserPreferences(v *viper.Viper, log *zerolog.Logger, colorEnabled, twelveHourEnabled bool, timezones []string) {
+	log.Debug().Bool("color", colorEnabled).Bool("twelveHour", twelveHourEnabled).Int("timezoneCount", len(timezones)).Msg("saving user preferences")
+
 	v.Set("color", colorEnabled)
 	v.Set("timezone", timezones)
 	v.Set("twelve-hour", twelveHourEnabled)
 
 	if err := v.WriteConfig(); err != nil {
 		log.Error().Err(err).Msg("failed to save preferences")
+	} else {
+		log.Debug().Msg("preferences saved successfully")
 	}
 }
 
 // processTimezones collects timezone information for all configured timezones.
-func processTimezones() (timezoneDetails, error) {
+func processTimezones(timezones []string, date string, log *zerolog.Logger) (timezoneDetails, error) {
+	log.Debug().Int("count", len(timezones)).Msg("processing timezones")
+
 	zones := make(timezoneDetails, 0, len(timezones))
 	for _, tz := range timezones {
-		zone, err := getZoneInfo(tz, date)
+		zone, err := getZoneInfo(tz, date, log)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process timezone %q: %w", tz, err)
 		}
 		zones = append(zones, zone)
 	}
+
+	log.Info().Int("count", len(zones)).Msg("timezones processed successfully")
 	return zones, nil
 }
 
 // processHighlightFlag parses and validates the highlight flag if provided.
-func processHighlightFlag(cmd *cobra.Command, zones timezoneDetails) (int, error) {
+func processHighlightFlag(cmd *cobra.Command, zones timezoneDetails, highlight string, log *zerolog.Logger) (int, error) {
 	if !cmd.Flags().Changed("highlight") {
 		return -1, nil
 	}
+
+	log.Debug().Str("highlight", highlight).Msg("processing highlight flag")
 
 	highlightHour, err := parseHighlightFlag(highlight, zones)
 	if err != nil {
 		return -1, fmt.Errorf("invalid highlight specification: %w", err)
 	}
 
+	log.Debug().Int("highlightHour", highlightHour).Msg("highlight column calculated")
 	return highlightHour, nil
 }

--- a/cmd/wizard_test.go
+++ b/cmd/wizard_test.go
@@ -220,6 +220,9 @@ func Test_wizardModel_removeFromSelected(t *testing.T) {
 }
 
 func Test_wizardCmd_exists(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := NewRootCmd()
 	found := false
 	for _, cmd := range rootCmd.Commands() {
 		if cmd.Use == "wizard" {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -28,6 +28,7 @@ var sharedLogger zerolog.Logger
 func init() {
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
 	zerolog.TimeFieldFormat = time.RFC3339
+	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
 
 	var output io.Writer = zerolog.ConsoleWriter{
 		Out:        os.Stderr,
@@ -35,7 +36,6 @@ func init() {
 	}
 
 	sharedLogger = zerolog.New(output).
-		Level(zerolog.ErrorLevel).
 		With().
 		Timestamp().
 		Logger()
@@ -73,5 +73,12 @@ func SetLogLevel(verboseCount int) {
 			level = zerolog.ErrorLevel
 		}
 	}
-	sharedLogger = sharedLogger.Level(level)
+	zerolog.SetGlobalLevel(level)
+}
+
+// Disable disables all logging output.
+// This is useful for interactive modes (e.g., TUI) where log output
+// would interfere with the display.
+func Disable() {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -74,9 +74,9 @@ func Test_SetLogLevel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SetLogLevel(tt.verboseCount)
 
-			logger := GetLogger()
-			if logger.GetLevel() != tt.expectedLevel {
-				t.Errorf("Expected level %v, got %v", tt.expectedLevel, logger.GetLevel())
+			// Check global level since we use zerolog.SetGlobalLevel()
+			if zerolog.GlobalLevel() != tt.expectedLevel {
+				t.Errorf("Expected level %v, got %v", tt.expectedLevel, zerolog.GlobalLevel())
 			}
 		})
 	}


### PR DESCRIPTION
This pull request refactors the CLI application's command structure to eliminate global state, improving testability and logging. The `list` and `wizard` commands are now constructed via factory functions that return fresh instances, facilitating isolated tests. Logging is enhanced, including the ability to disable logs during interactive sessions. Test suites are updated for better isolation and concurrency. Additionally, pre-commit hooks for Go tests and coverage are added.

**Command Refactoring and Testability**
- Refactored `list` and `wizard` commands to use `NewListCmd` and `NewWizardCmd` factory functions, removing global state and allowing each test to use a fresh command instance. This improves test isolation and maintainability. (`cmd/list.go` [[1]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5L594-R599) [[2]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5L682-L691); `cmd/wizard.go` [[3]](diffhunk://#diff-c2f7d950373c95aa749e90baf517a7f8030edb1e22af5a08aba01a9501b660cbL1077-R1089) [[4]](diffhunk://#diff-c2f7d950373c95aa749e90baf517a7f8030edb1e22af5a08aba01a9501b660cbL1123-R1135)
- Updated tests to use the new command factories, added `t.Parallel()` for concurrency, and improved test structure for flag and argument validation. (`cmd/list_test.go` [[1]](diffhunk://#diff-de55b1c0727497d6b1c04e5a0ec34658609b205726ed784e3a75f6fc35885580R55-R78) [[2]](diffhunk://#diff-de55b1c0727497d6b1c04e5a0ec34658609b205726ed784e3a75f6fc35885580R121-R122) [[3]](diffhunk://#diff-de55b1c0727497d6b1c04e5a0ec34658609b205726ed784e3a75f6fc35885580L119-R133) [[4]](diffhunk://#diff-de55b1c0727497d6b1c04e5a0ec34658609b205726ed784e3a75f6fc35885580L151-R173) [[5]](diffhunk://#diff-de55b1c0727497d6b1c04e5a0ec34658609b205726ed784e3a75f6fc35885580L180-R190) [[6]](diffhunk://#diff-de55b1c0727497d6b1c04e5a0ec34658609b205726ed784e3a75f6fc35885580R234) [[7]](diffhunk://#diff-de55b1c0727497d6b1c04e5a0ec34658609b205726ed784e3a75f6fc35885580R244) [[8]](diffhunk://#diff-de55b1c0727497d6b1c04e5a0ec34658609b205726ed784e3a75f6fc35885580L260-R265) [[9]](diffhunk://#diff-de55b1c0727497d6b1c04e5a0ec34658609b205726ed784e3a75f6fc35885580R280); `cmd/wizard_test.go` [[10]](diffhunk://#diff-f79f3d77c85ead6c74427e67f27d6b0a642a922d5abe1db6b181b4e49809d4f1R223-R225)

**Logging Improvements**
- Centralized logging control: added `logger.Disable()` to suppress logs during TUI sessions and switched to using `zerolog.SetGlobalLevel()` for global log level management. (`logger/logger.go` [[1]](diffhunk://#diff-606d907279d517af7dab4f35f571671388c95c5a05e2c9fe033b08e0b4588348R31-L38) [[2]](diffhunk://#diff-606d907279d517af7dab4f35f571671388c95c5a05e2c9fe033b08e0b4588348L76-R83); `cmd/wizard.go` [[3]](diffhunk://#diff-c2f7d950373c95aa749e90baf517a7f8030edb1e22af5a08aba01a9501b660cbL1051-R1058)
- Adjusted logger tests to check the global log level instead of per-logger level. (`logger/logger_test.go` [logger/logger_test.goL77-R79](diffhunk://#diff-b9d87dbc6149275d8199d707bb7236e54a99d46082c277b047a4a0d81be80ddcL77-R79))

**Pre-commit and Changelog Enhancements**
- Added local pre-commit hooks for running Go tests and enforcing code coverage (minimum 85%). (`.pre-commit-config.yaml` [.pre-commit-config.yamlR18-R33](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R18-R33))